### PR TITLE
Replace CI bash loop with Makefile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,16 +43,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Build image
-        run: |
-          set -a
-          . ./versions/${{ matrix.php-versions }}.env
-          set +a
-          args=()
-          while IFS='=' read -r k _; do
-            [[ -z "$k" || "$k" =~ ^# ]] && continue
-            args+=(--build-arg "$k")
-          done < versions/${{ matrix.php-versions }}.env
-          docker image build "${args[@]}" --tag utopia-base-test .
+        run: make build VERSION=${{ matrix.php-versions }} IMAGE=utopia-base-test
 
       - name: Save image
         run: docker image save utopia-base-test -o image.tar

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+VERSION ?= 8.4
+IMAGE ?= utopia-base-test
+ENV_FILE := versions/$(VERSION).env
+
+BUILD_ARGS := $(shell awk -F= '!/^\#/ && NF { printf "--build-arg %s ", $$1 }' $(ENV_FILE))
+
+.PHONY: build test all clean
+
+build:
+	set -a && . ./$(ENV_FILE) && set +a && \
+	docker build $(BUILD_ARGS) --tag $(IMAGE) .
+
+test: build
+	container-structure-test test --image $(IMAGE) --config tests.yaml
+
+all:
+	$(MAKE) build VERSION=8.3
+	$(MAKE) build VERSION=8.4
+	$(MAKE) build VERSION=8.5
+
+clean:
+	docker rmi $(IMAGE) 2>/dev/null || true

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
 VERSION ?= 8.4
-IMAGE ?= utopia-base-test
+IMAGE ?= utopia-base-test:$(VERSION)
 ENV_FILE := versions/$(VERSION).env
 
-BUILD_ARGS := $(shell awk -F= '!/^\#/ && NF { printf "--build-arg %s ", $$1 }' $(ENV_FILE))
+VERSIONS := $(patsubst versions/%.env,%,$(wildcard versions/*.env))
+
+BUILD_ARGS = $(shell awk -F= '!/^\#/ && NF { printf "--build-arg %s ", $$1 }' $(ENV_FILE))
 
 .PHONY: build test all clean
 
@@ -14,9 +16,7 @@ test: build
 	container-structure-test test --image $(IMAGE) --config tests.yaml
 
 all:
-	$(MAKE) build VERSION=8.3
-	$(MAKE) build VERSION=8.4
-	$(MAKE) build VERSION=8.5
+	@for v in $(VERSIONS); do $(MAKE) build VERSION=$$v || exit $$?; done
 
 clean:
-	docker rmi $(IMAGE) 2>/dev/null || true
+	@for v in $(VERSIONS); do docker rmi utopia-base-test:$$v 2>/dev/null || true; done

--- a/README.md
+++ b/README.md
@@ -34,18 +34,12 @@ All publishing workflows share a `build-<sha>` concurrency group so a release qu
 
 ## Local development
 
-A single `Dockerfile` is templated by the per-version configs in `versions/<X.Y>.env`:
+A single `Dockerfile` is templated by the per-version configs in `versions/<X.Y>.env`. Use the `Makefile`:
 
 ```sh
-set -a && . versions/8.4.env && set +a
-args=()
-while IFS='=' read -r k _; do
-  [[ -z "$k" || "$k" =~ ^# ]] && continue
-  args+=(--build-arg "$k")
-done < versions/8.4.env
-
-docker build "${args[@]}" -t utopia-base-test .
-container-structure-test test --image utopia-base-test --config tests.yaml
+make build VERSION=8.4              # build a single version
+make test VERSION=8.4               # build + run structure tests
+make all                            # build all supported versions
 ```
 
 To bump an extension version, edit the relevant `versions/<X.Y>.env`. To add a new PHP version, drop in a new `versions/<X.Y>.env` and add the version to the matrix in `.github/workflows/ci.yml` and `publish.yml`.


### PR DESCRIPTION
## Summary
- The bash arg-extraction loop introduced in #11 for sourcing `versions/<X.Y>.env` and turning each key into a `--build-arg` flag was hard to read and not reusable locally.
- Replace with a small `Makefile` exposing `make build`, `make test`, and `make all`.
- `ci.yml` now calls `make build VERSION=… IMAGE=utopia-base-test` instead of inlining shell.
- README updated to document the make targets.

Stacked on top of #11 — please review/merge that one first.

## Test plan
- [ ] CI builds all three versions × both arches green via `make build`
- [ ] `make test VERSION=8.4` passes locally with `container-structure-test` installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)